### PR TITLE
Use relative paths instead of absolute paths, visit React.Fragment's children elements.

### DIFF
--- a/packages/swc-plugin-react-scoped-css/src/lib.rs
+++ b/packages/swc-plugin-react-scoped-css/src/lib.rs
@@ -19,5 +19,14 @@ pub fn process_transform(program: Program, data: TransformPluginProgramMetadata)
         Some(s) => FileName::Real(s.into()),
         None => FileName::Anon,
     };
-    program.fold_with(&mut react_scoped_css(config, file_name.to_string()))
+    let current_dir = std::env::current_dir().unwrap();
+    let file_path = current_dir.join(file_name.to_string());
+    let relative_path = file_path
+        .strip_prefix(&current_dir)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    program.fold_with(&mut react_scoped_css(config, relative_path.clone()))
 }

--- a/packages/swc-plugin-react-scoped-css/transform/src/visitor.rs
+++ b/packages/swc-plugin-react-scoped-css/transform/src/visitor.rs
@@ -66,6 +66,7 @@ impl VisitMut for ReactScopedCssVistor {
         if self.has_scoped_css {
             match element.opening.name {
                 swc_core::ecma::ast::JSXElementName::JSXMemberExpr(ref member_expr) => {
+                    element.visit_mut_children_with(self);
                     return;
                 }
                 _ => {}

--- a/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/frag/output.jsx
+++ b/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/frag/output.jsx
@@ -5,7 +5,7 @@ const Frag = ()=>{
 
       <React.Fragment>
 
-        <div className="test-frag"></div>
+        <div className="test-frag" data-v-848cb8dd=""></div>
 
       </React.Fragment>
 

--- a/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/frag/output.jsx
+++ b/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/frag/output.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import "./frag.scoped.css?scopeId=b9d0f0e5";
+import "./frag.scoped.css?scopeId=848cb8dd";
 const Frag = ()=>{
-    return <div data-v-b9d0f0e5="">
+    return <div data-v-848cb8dd="">
 
       <React.Fragment>
 
@@ -11,7 +11,7 @@ const Frag = ()=>{
 
       <>
 
-        <div data-v-b9d0f0e5="">text</div>
+        <div data-v-848cb8dd="">text</div>
 
       </>
 

--- a/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/from-example/output.jsx
+++ b/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/from-example/output.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
-import styles from "./Content.scoped.scss?scopeId=e11877f5";
+import styles from "./Content.scoped.scss?scopeId=4cfc5488";
 import Grid from './Grid';
 import GridForwardProps from './GridForwardProps';
 const Text = styled.div`
   color: #666;
 `;
 const FromExample = (props)=>{
-    return <div className="content" data-v-e11877f5="">
+    return <div className="content" data-v-4cfc5488="">
 
-      <h3 data-v-e11877f5="">Styling html tags</h3>
+      <h3 data-v-4cfc5488="">Styling html tags</h3>
 
-      <p data-v-e11877f5="">p tag with style</p>
+      <p data-v-4cfc5488="">p tag with style</p>
 
 
 
@@ -27,23 +27,23 @@ const FromExample = (props)=>{
 
 
 
-      <h3 data-v-e11877f5="">Using classes</h3>
+      <h3 data-v-4cfc5488="">Using classes</h3>
 
-      <div className="grid" data-v-e11877f5=""/>
+      <div className="grid" data-v-4cfc5488=""/>
 
-      <div className="grid" data-v-e11877f5=""/>
-
-
-
-      <h3 data-v-e11877f5="">Styling child components with css modules</h3>
-
-      <Grid className={styles.grid} data-v-e11877f5=""/>
-
-      <Grid className={styles.grid} data-v-e11877f5=""/>
+      <div className="grid" data-v-4cfc5488=""/>
 
 
 
-      <h3 data-v-e11877f5="">
+      <h3 data-v-4cfc5488="">Styling child components with css modules</h3>
+
+      <Grid className={styles.grid} data-v-4cfc5488=""/>
+
+      <Grid className={styles.grid} data-v-4cfc5488=""/>
+
+
+
+      <h3 data-v-4cfc5488="">
 
         Styling child components which forward data-v attributes to its root
 
@@ -51,15 +51,15 @@ const FromExample = (props)=>{
 
       </h3>
 
-      <GridForwardProps className="content-grid" data-v-e11877f5=""/>
+      <GridForwardProps className="content-grid" data-v-4cfc5488=""/>
 
-      <GridForwardProps className="content-grid" data-v-e11877f5=""/>
+      <GridForwardProps className="content-grid" data-v-4cfc5488=""/>
 
 
 
-      <h3 data-v-e11877f5="">Styling with styled-components</h3>
+      <h3 data-v-4cfc5488="">Styling with styled-components</h3>
 
-      <Text className="text" data-v-e11877f5="">Some content in styled-components</Text>
+      <Text className="text" data-v-4cfc5488="">Some content in styled-components</Text>
 
     </div>;
 };

--- a/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/from-example/output.jsx
+++ b/packages/swc-plugin-react-scoped-css/transform/tests/fixtures/from-example/output.jsx
@@ -17,9 +17,9 @@ const FromExample = (props)=>{
 
       <React.Fragment>
 
-        <div>
+        <div data-v-4cfc5488="">
 
-          <p>content wrapped with React Fragment should be fine</p>
+          <p data-v-4cfc5488="">content wrapped with React Fragment should be fine</p>
 
         </div>
 

--- a/packages/swc-plugin-react-scoped-css/transform/tests/test.rs
+++ b/packages/swc-plugin-react-scoped-css/transform/tests/test.rs
@@ -17,10 +17,22 @@ mod test {
     #[fixture("tests/fixtures/**/input.jsx")]
     fn tests(input: PathBuf) {
         let output = input.parent().unwrap().join("output.jsx");
-        println!("{}", input.display().to_string());
+
+        let file_name = input.to_str().unwrap().to_string();
+        let current_dir = std::env::current_dir().unwrap();
+        let file_path = current_dir.join(file_name.to_string());
+        let relative_path = file_path
+            .strip_prefix(&current_dir)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        println!("{}", relative_path.clone());
+
         test_fixture(
             syntax(),
-            &|_| react_scoped_css(Config::default(), input.display().to_string()),
+            &|_| react_scoped_css(Config::default(), relative_path.clone()),
             &input,
             &output,
             Default::default(),


### PR DESCRIPTION
### Use relative paths instead of absolute paths:
Ref: https://github.com/gaoxiaoliangz/react-scoped-css/blob/main/packages/babel-plugin-react-scoped-css/index.js#L29

* [`packages/swc-plugin-react-scoped-css/src/lib.rs`](diffhunk://#diff-2358a91e93bf89f7a9f4ec909f6974db968cbb06a4927914517302fe2add765bL22-R31): Modified the `process_transform` function to convert file paths to relative paths before passing them to the `react_scoped_css` function.
* [`packages/swc-plugin-react-scoped-css/transform/tests/test.rs`](diffhunk://#diff-96e8fe8726a982738b8a5e6e0fc41103950409b15a8a6fe934a43f8df546fa38L20-R35): Updated the test function to print and use relative paths instead of absolute paths.

### Ensure all children elements are visited:
 Ref: https://github.com/gaoxiaoliangz/react-scoped-css/blob/main/packages/babel-plugin-react-scoped-css/__snapshots__/index.spec.js.snap#L10

* [`packages/swc-plugin-react-scoped-css/transform/src/visitor.rs`](diffhunk://#diff-7117920aa24925ce63937fa8b0f9c2e66253f102d955b6de60b561485c17a452R69): Added a call to `visit_mut_children_with` within the `ReactScopedCssVisitor` implementation to ensure all children elements are visited.

### Test fixture updates:

* [`packages/swc-plugin-react-scoped-css/transform/tests/fixtures/frag/output.jsx`](diffhunk://#diff-c1eaca6906382b028a9a3cde485064ee4dd9f7ac1c62ebedc49c3eecd7c7463cL2-R14): Updated the scope ID in the test fixture to `848cb8dd`.
* [`packages/swc-plugin-react-scoped-css/transform/tests/fixtures/from-example/output.jsx`](diffhunk://#diff-63561aec8a33aa6cb550104a5e1b82e5efac029866aae9721d1efab75e312e4cL3-R62): Updated the scope ID in the test fixture to `4cfc5488`.